### PR TITLE
fix: Get correct AST Id value

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,34 +15,22 @@
     "validate": "npm run lint && npm run flow && npm run test"
   },
   "lint-staged": {
-    "src/**/*.js": [
-      "fmt",
-      "validate",
-      "git add"
-    ],
-    "*.json": [
-      "fmt",
-      "git add"
-    ]
+    "src/**/*.js": ["fmt", "validate", "git add"],
+    "*.json": ["fmt", "git add"]
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/adam-26/babel-plugin-react-intl-id-hash.git"
   },
-  "keywords": [
-    "react-intl",
-    "id",
-    "hash"
-  ],
+  "keywords": ["react-intl", "id", "hash"],
   "author": "adam-26",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/adam-26/babel-plugin-react-intl-id-hash/issues"
   },
-  "homepage": "https://github.com/adam-26/babel-plugin-react-intl-id-hash#readme",
-  "files": [
-    "lib"
-  ],
+  "homepage":
+    "https://github.com/adam-26/babel-plugin-react-intl-id-hash#readme",
+  "files": ["lib"],
   "dependencies": {
     "babel-types": "^6.26.0",
     "murmurhash-js": "^1.0.0"

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -18,7 +18,7 @@ import { defineMessages } from 'react-intl';
 
 export default defineMessages({
   new: {
-    'id': 'GSplhw==',
+    'id': 'kN4IPA==',
 
     defaultMessage: 'id',
     description: 'describe text for translation'
@@ -45,7 +45,7 @@ import { defineMessages } from 'react-intl';
 
 export default defineMessages({
   new: {
-    'id': 'GSplhw==',
+    'id': 'kN4IPA==',
 
     defaultMessage: 'id',
     description: 'describe text for translation'
@@ -120,7 +120,7 @@ import { defineMessages } from 'react-intl';
 
 export default defineMessages({
   new: {
-    \\"id\\": \\"GSplhw==\\",
+    \\"id\\": \\"kN4IPA==\\",
 
     \\"defaultMessage\\": \\"id\\",
     \\"description\\": \\"describe text for translation\\"
@@ -147,7 +147,7 @@ import { defineMessages } from 'react-intl';
 
 export default defineMessages({
   new: {
-    \\"id\\": \\"GSplhw==\\",
+    \\"id\\": \\"kN4IPA==\\",
 
     \\"defaultMessage\\": \\"id\\",
     \\"description\\": \\"describe text for translation\\"

--- a/src/murmurHash.js
+++ b/src/murmurHash.js
@@ -1,0 +1,16 @@
+// @flow
+import murmurhashJs from 'murmurhash-js'
+
+// https://stackoverflow.com/questions/15761790/convert-a-32bit-integer-into-4-bytes-of-data-in-javascript
+function toBytesInt32(num: number) {
+  const arr = new ArrayBuffer(4)
+  const view = new DataView(arr)
+  view.setUint32(0, num, false)
+  return arr
+}
+
+function murmur3Hash(id: string) {
+  return Buffer.from(toBytesInt32(murmurhashJs(id))).toString('base64')
+}
+
+export default murmur3Hash


### PR DESCRIPTION
Has been using the object property key and not the ‘id’ value for creating the message hash id. This commit resolves this bug.